### PR TITLE
Online Python Training (OPT) not OTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # online-python-training
-Repo for materials associated with the Online Training Project (OTP)
+Repo for materials associated with the Online Python Training (OPT)


### PR DESCRIPTION
Closes #105 @dopplershift could you change the project subtitle to: "Repo for materials associated with the Online Python Training (OPT) http://unidata.github.io/online-python-training/". Only the project owner change that, I believe.