### PR TITLE
Bump requests to 2.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
 before_install:
   - gem install github-pages
   - pip install --user --upgrade pyopenssl
-  - pip install --user ndg-httpsclient pyasn1 "requests[security]>=2.4.0" "urllib3[secure]>=1.22"
+  - pip install --user ndg-httpsclient pyasn1 "requests[security]>=2.22.0" "urllib3[secure]>=1.22"
   - pip install --user git+https://github.com/linkcheck/linkchecker
 
 script:


### PR DESCRIPTION
In trying to deduce what's up with the broken build, I saw it passed when requests was 2.22, but failed when it was 2.9. It wasn't clear to me why the requirement was already satisfied when it got to the install command in this most recent build, but I'll try bumping it here and see if things pass or not. 